### PR TITLE
RTFACT-8179 Add server header to indicate servicing web server

### DIFF
--- a/buildSrc/src/main/resources/nginx/artifactory.conf
+++ b/buildSrc/src/main/resources/nginx/artifactory.conf
@@ -11,6 +11,7 @@ server {
     proxy_set_header    Host  $host;
     proxy_set_header 	  X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header 	  X-Real-IP      $remote_addr; # pass on real client's IP
+    proxy_pass_header   Server;
   }
 }
 
@@ -39,5 +40,6 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Ssl on;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass_header   Server;
   }
 }

--- a/buildSrc/src/main/resources/nginx/artifactoryDocker.conf
+++ b/buildSrc/src/main/resources/nginx/artifactoryDocker.conf
@@ -12,6 +12,7 @@ server {
     proxy_set_header 	  X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header 	  X-Real-IP      $remote_addr; # pass on real client's IP
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass_header   Server;
   }
 }
 
@@ -40,6 +41,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Ssl on;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass_header   Server;
   }
 }
 
@@ -64,6 +66,7 @@ server {
   proxy_set_header 	  X-Real-IP      $remote_addr; # pass on real client's IP
   proxy_set_header X-Forwarded-Ssl on;
   proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_pass_header   Server;
 
   location /v1 {
     proxy_pass          http://localhost:8081/artifactory/api/docker/docker-prod-local/v1;
@@ -95,6 +98,7 @@ server {
   proxy_set_header 	  X-Real-IP      $remote_addr; # pass on real client's IP
   proxy_set_header X-Forwarded-Ssl on;
   proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_pass_header   Server;
 
   location /v1 {
     proxy_pass          http://localhost:8081/artifactory/api/docker/docker-dev-local/v1;
@@ -126,6 +130,7 @@ server {
   proxy_set_header 	  X-Real-IP      $remote_addr; # pass on real client's IP
   proxy_set_header X-Forwarded-Ssl on;
   proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_pass_header   Server;
 
   location /v2/ {
     proxy_pass          http://localhost:8081/artifactory/api/docker/docker-remote/v2/;


### PR DESCRIPTION
Adding the proxy_pass_header configuration to nginx makes problems easier to debug.  You can see which server actually is doing the reply. 
